### PR TITLE
Allow for LaTeX in posts, add demonstration in shellsort post

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,2 @@
 theme: jekyll-theme-midnight
+markdown: kramdown

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,7 +8,7 @@
     <script type="text/javascript" async
       src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_CHTML">
     </script>
-{% end if %}
+{% endif %}
 
 {% seo %}
     <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,66 @@
+<!doctype html>
+<html lang="{{ site.lang | default: "en-US" }}">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    
+{% if page.usemathjax %}
+    <script type="text/javascript" async
+      src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_CHTML">
+    </script>
+{% end if %}
+
+{% seo %}
+    <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
+    <script src="https://code.jquery.com/jquery-1.12.4.min.js" integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ=" crossorigin="anonymous"></script>
+    <script src="{{ '/assets/js/respond.js' | relative_url }}"></script>
+    <!--[if lt IE 9]>
+      <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
+    <![endif]-->
+    <!--[if lt IE 8]>
+    <link rel="stylesheet" href="{{ '/assets/css/ie.css' | relative_url }}">
+    <![endif]-->
+    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+
+  </head>
+  <body>
+      <div id="header">
+        <nav>
+          <li class="fork"><a href="{{ site.github.repository_url }}">View On GitHub</a></li>
+          {% if site.show_downloads %}
+            <li class="downloads"><a href="{{ site.github.zip_url }}">ZIP</a></li>
+            <li class="downloads"><a href="{{ site.github.tar_url }}">TAR</a></li>
+            <li class="title">DOWNLOADS</li>
+          {% endif %}
+        </nav>
+      </div><!-- end header -->
+
+    <div class="wrapper">
+
+      <section>
+        <div id="title">
+          <h1>{{ site.title | default: site.github.repository_name }}</h1>
+          <p>{{ site.description | default: site.github.project_tagline }}</p>
+          <hr>
+          <span class="credits left">Project maintained by <a href="{{ site.github.owner_url }}">{{ site.github.owner_name }}</a></span>
+          <span class="credits right">Hosted on GitHub Pages &mdash; Theme by <a href="https://twitter.com/mattgraham">mattgraham</a></span>
+        </div>
+
+        {{ content }}
+
+      </section>
+
+    </div>
+
+    {% if site.google_analytics %}
+      <script>
+        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+        ga('create', '{{ site.google_analytics }}', 'auto');
+        ga('send', 'pageview');
+      </script>
+    {% endif %}
+  </body>
+</html>

--- a/posts/20201015_shellsort.md
+++ b/posts/20201015_shellsort.md
@@ -11,7 +11,7 @@ on 25 elements*. The official [solver](https://github.com/dm248/shellsort-13-4-1
 (trying all 25! permutations). So that got me curious, is the problem doable?
 Well, it turns out that it is, though not quite that way (check the [code](https://github.com/dm248/shellsort-13-4-1) on GitHub, if interested).
 
-First off, $$25!$$ is ballpark $$10^25$$, clearly hopeless - one needs to bring the work down to a trillion 
+First off, $$25!$$ is ballpark $$10^{25}$$, clearly hopeless - one needs to bring the work down to a trillion 
 (10^12) or so cases to be in business. Assume that all elements are distinct, and let those be 0...24
 in sorted order (values are irrelevant, only < > relationships matter in sorting anyway). Recall what 
 (13,4,1) shellsort does:

--- a/posts/20201015_shellsort.md
+++ b/posts/20201015_shellsort.md
@@ -1,3 +1,6 @@
+---
+usemathjax: true
+---
 # Curious case of (13,4,1) shellsort
 
 ##### Oct 15, 2020
@@ -8,12 +11,12 @@ on 25 elements*. The official [solver](https://github.com/dm248/shellsort-13-4-1
 (trying all 25! permutations). So that got me curious, is the problem doable?
 Well, it turns out that it is, though not quite that way (check the [code](https://github.com/dm248/shellsort-13-4-1) on GitHub, if interested).
 
-First off, 25! is ballpark **10^25**, clearly hopeless - one needs to bring the work down to a trillion 
+First off, $$25!$$ is ballpark $$10^25$$, clearly hopeless - one needs to bring the work down to a trillion 
 (10^12) or so cases to be in business. Assume that all elements are distinct, and let those be 0...24
 in sorted order (values are irrelevant, only < > relationships matter in sorting anyway). Recall what 
 (13,4,1) shellsort does:
 it uses insertion sort to [*h*-sort](https://en.wikipedia.org/wiki/Shellsort) the elements 
-first using *h*=13, then by *h*=4, and finally *h*=1.
+first using $$h=13$$, then by $$h=4$$, and finally *h*=1.
 Here, *h*-sorting means separately sorting every subset of elements that are at the same position modulo *h* 
 (there are *h* such subsets given by the position 0...(h-1) of the first element in the set),
 and the result is said to be *h-ordered*.
@@ -23,8 +26,8 @@ the one where S is kept unchanged).
 
 ### Strategy
 
-Suppose the 13-sort does *x* swaps, the 4-sort *y*, and the final 1-sort *z* swaps. Then, in total, 
-there are *x* + *y* + *z* swaps, and we want to maximize this sum. The first step, 13-sort, compares 12 
+Suppose the 13-sort does $$x$$ swaps, the 4-sort $$y$$, and the final 1-sort $$z$$ swaps. Then, in total, 
+there are $$x + y + z$$ swaps, and we want to maximize this sum. The first step, 13-sort, compares 12 
 pairs of elements - at positions (0,13), (1,14), ... (11,24) - so there are 2^12 ways to unsort this. We can 
 always pick the one that takes the maximal swaps to 13-sort, i.e., **x = 12**. Considering the results of 
 the 13-sort, there are still 25! / 2^12 possibilities, far too many to enumerate. Then comes the 


### PR DESCRIPTION
This change allows you to use LaTeX in your posts. I added a little demonstration in the start of the shellsort post to show you how. I think for more mathematically oriented posts this helps a lot with readability.

See top of http://blog.ammaraskar.com/dm248.github.io/posts/20201015_shellsort.html for example